### PR TITLE
Set `primary = true` on the generated user email

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,8 @@ resource "aws_identitystore_user" "this" {
   }
 
   emails {
-    value = lower(each.value.email)
+    value   = lower(each.value.email)
+    primary = true
   }
 }
 


### PR DESCRIPTION
## What
Marks the email created for each `aws_identitystore_user` as **primary** (`primary = true`).

## Why
IAM Identity Center stores the email without the primary flag today. Anything that resolves a
user's **primary** email then finds none — most notably SAML attribute mappings that use
`${user:email}` for the Subject/NameID (e.g. AWS Client VPN federated authentication), which
fail with "Resource not found / confirm your primary email address is assigned in IAM Identity
Center".

## Change
`main.tf` — the `emails` block now sets `primary = true` (each user has a single email, which
should be the primary one).

## Testing
Applied in production (in-place user updates, no replacement) — users' emails are now flagged
primary and SAML sign-in via `${user:email}` resolves correctly.
